### PR TITLE
Code changes to support automatic debug compilation

### DIFF
--- a/lanl_cice/bld/Macros.Linux.NEMS.cheyenne
+++ b/lanl_cice/bld/Macros.Linux.NEMS.cheyenne
@@ -16,10 +16,10 @@ FFLAGS_DEBUG := -g -O0 -fp-model precise -convert big_endian -assume byterecl -f
 FFLAGS_OPT   := -O2 -fp-model precise -convert big_endian -assume byterecl -ftz -traceback   -xHost -I$(NETCDF)/include
 FFLAGS_NOOPT:= -O0
 
-ifdef DEBUG
-FFLAGS += $(FFLAGS_DEBUG)
+ifeq ($(DEBUG),Y)
+  FFLAGS += $(FFLAGS_DEBUG)
 else
-FFLAGS += $(FFLAGS_OPT)
+  FFLAGS += $(FFLAGS_OPT)
 endif
 
 ifeq ($(COMMDIR), mpi)

--- a/lanl_cice/bld/Macros.Linux.NEMS.hera
+++ b/lanl_cice/bld/Macros.Linux.NEMS.hera
@@ -4,8 +4,6 @@
 # For use with intel compiler with IntelMPI
 #==============================================================================
 
-DEBUG=  
-
 CPP        := fpp
 CPPDEFS    := -DFORTRANUNDERSCORE -DNO_R16 -DHAVE_F2008_CONTIGUOUS -DLINUX -DCPRINTEL -DCICE_NEMS
 CFLAGS     := -c -O2 -fp-model precise   -xHost
@@ -22,10 +20,10 @@ else
   FC         := ifort
 endif
 
-ifdef DEBUG
-FFLAGS += $(FFLAGS_DEBUG)
+ifeq ($(DEBUG),Y)
+  FFLAGS += $(FFLAGS_DEBUG)
 else
-FFLAGS += $(FFLAGS_OPT)
+  FFLAGS += $(FFLAGS_OPT)
 endif
 
 MPICC:= mpiicc

--- a/lanl_cice/comp_ice.backend
+++ b/lanl_cice/comp_ice.backend
@@ -206,9 +206,21 @@ else
   cc -o makdep $CBLD/makdep.c
 endif
 
+# Build in debug mode. If DEBUG=Y, enable DEBUG compilation. This
+# flag is set in ${ROOTDIR}/coupledFV3_MOM6_CICE_debug.appBuilder file.
+if (! $?DEBUG) then
+  set DEBUG = N
+else
+  if ($DEBUG != "Y") then
+    set DEBUG = N
+  endif
+endif
+echo "CICE comp_ice.backend ... DEBUG=${DEBUG}"
+
 gmake VPFILE=Filepath EXEC=$EXEDIR/cice \
            NXGLOB=$NXGLOB NYGLOB=$NYGLOB \
            BLCKX=$BLCKX BLCKY=$BLCKY MXBLCKS=$MXBLCKS \
+           DEBUG=$DEBUG \
       -f  $CBLD/Makefile MACFILE=$CBLD/Macros.$ARCH 
 
 cd ..


### PR DESCRIPTION
1. comp_ice.backend receives DEBUG as an environment variable, and passes it down to the makefile.
2. Macros.Linux.NEMS.hera selects FFLAGS based on the DEBUG flag it receives.

This resolves issue #9 