### PR TITLE
Revised bld/Macros.Linux.NEMS.wcoss.

### DIFF
--- a/lanl_cice/bld/Macros.Linux.NEMS.wcoss
+++ b/lanl_cice/bld/Macros.Linux.NEMS.wcoss
@@ -10,13 +10,20 @@ CFLAGS     := -c -O2 -fp-model precise -xHost -g -traceback
 
 FIXEDFLAGS := -132
 FREEFLAGS  := -FR
-FFLAGS     := -O2 -fp-model precise -convert big_endian -assume byterecl -ftz -traceback -xHost -g -traceback
+FFLAGS_DEBUG := -g -O0 -fp-model precise -convert big_endian -assume byterecl -ftz -traceback -link_mpi=dbg -xHost
+FFLAGS_OPT   := -O2 -fp-model precise -convert big_endian -assume byterecl -ftz -traceback -xHost -g -traceback
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(COMMDIR), mpi)
   FC         := mpiifort
 else
   FC         := ifort
+endif
+
+ifeq ($(DEBUG),Y)
+  FFLAGS += $(FFLAGS_DEBUG)
+else
+  FFLAGS += $(FFLAGS_OPT)
 endif
 
 MPICC:= mpiicc


### PR DESCRIPTION
The runs with debug mode are successful once the revised Macros.Linux.NEMS.wcoss is used for CICE5.
close #21 